### PR TITLE
Changed all pointers to allocatable arrays.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 jobs:
-  build:
-    name: Run Fortran tests
+  build1:
+    name: Tests for GNU compiler + OpenBLAS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,14 +14,40 @@ jobs:
         uses: actions/setup-python@v2
       - name: Install dependencies
         run: |
-            sudo apt-get --yes install ccache
-            sudo apt-get update -q -y
-            sudo apt-get install -y libopenblas-base libopenblas-dev
-            pip3 install sparse-ir xprec
-
+          sudo apt-get --yes install ccache
+          sudo apt-get update -q -y
+          sudo apt-get install -y libopenblas-base libopenblas-dev
+          pip3 install sparse-ir xprec
       - name: Test fortran interface
         run: |
           cp Makefile.gfortran_openblas Makefile
+          pwd
+          ls -l
+          ./runtest.sh
+
+  build2:
+    name: Tests for Intel compiler + Intel MKL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python
+        uses: actions/setup-python@v2
+      - name: Set up repo
+        run: |
+          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt-get update
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y intel-oneapi-common-vars
+          sudo apt-get install -y intel-oneapi-compiler-fortran
+          sudo apt-get install -y intel-oneapi-mkl-devel
+          source /opt/intel/oneapi/setvars.sh
+          printenv >> $GITHUB_ENV
+          pip3 install sparse-ir xprec
+      - name: "Test fortran interface"
+        run: |
+          cp Makefile.ifort_mkl Makefile
           pwd
           ls -l
           ./runtest.sh

--- a/Makefile.gfortran_openblas
+++ b/Makefile.gfortran_openblas
@@ -2,7 +2,7 @@ FC = gfortran
 
 LDLIBS = -lblas -llapack
 LDFLAGS = -L/usr/lib/x86_64-linux-gnu
-F90FLAGS = -std=f2008 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
+F90FLAGS = -std=f2003 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
 
 TARGET = test_sparse_ir
 OBJS = test_sparse_ir.o sparse_ir.o sparse_ir_io.o sparse_ir_preset.o

--- a/Makefile.ifort_mkl
+++ b/Makefile.ifort_mkl
@@ -1,8 +1,9 @@
-FC = gfortran
+FC = ifort
 
-LDLIBS = -lblas -llapack
-LDFLAGS = -L/usr/lib/x86_64-linux-gnu
-F90FLAGS = -std=f2008 -Wall -fbounds-check -g -fcheck=array-temps,bounds,do,mem,pointer,recursion
+LDLIBS = -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
+#LDLIBS = -mkl=sequential
+LDFLAGS = -static-intel
+F90FLAGS = -O2 -g -traceback
 
 TARGET = test_sparse_ir
 OBJS = test_sparse_ir.o sparse_ir.o sparse_ir_io.o sparse_ir_preset.o

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -188,6 +188,8 @@ module sparse_ir
 
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
+        ! inv_s temporarily stores the same data of inv_s_dl
+        dmat%inv_s(1:ns) = dmat%inv_s_dl(1:ns)
         dmat%ut(1:ns, 1:m) = conjg(transpose(u(1:m, 1:ns)))
         dmat%v(1:n, 1:ns) = conjg(transpose(vt(1:ns, 1:n)))
         dmat%m = size(a, 1)
@@ -246,6 +248,8 @@ module sparse_ir
 
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
+        ! inv_s temporarily stores the same data of inv_s_dl
+        dmat%inv_s(1:ns) = dmat%inv_s_dl(1:ns)
         dmat%ut(1:ns, 1:m) = conjg(transpose(u(1:m, 1:ns)))
         dmat%v(1:n, 1:ns) = conjg(transpose(vt(1:ns, 1:n)))
         dmat%m = size(a, 1)

--- a/sparse_ir.f90
+++ b/sparse_ir.f90
@@ -191,6 +191,7 @@ module sparse_ir
         allocate(dmat%ut(ns, m))
         allocate(dmat%v(n, ns))
 
+        ! dmat%a temporarily stores the same data of input a
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
         ! inv_s temporarily stores the same data of inv_s_dl
@@ -251,6 +252,7 @@ module sparse_ir
         allocate(dmat%ut(ns, m))
         allocate(dmat%v(n, ns))
 
+        ! dmat%a temporarily stores the same data of input a
         dmat%a = a
         dmat%inv_s_dl(1:ns) = 1.0D0 / s(1:ns)
         ! inv_s temporarily stores the same data of inv_s_dl

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -39,6 +39,7 @@ program main
         end if
         !write(*, *) y
         !write(*, *) y_reconst
+        call finalize_dmat(dm)
     end subroutine
 
     subroutine test_over_fitting()
@@ -58,6 +59,7 @@ program main
         if (maxval(abs(y - y_reconst)) > 1e-12) then
             stop "y and y_reconst do not match!"
         end if
+        call finalize_dmat(dm)
     end subroutine
 
 
@@ -84,6 +86,7 @@ program main
         if (maxval(abs(y - y_reconst)) > 1e-12) then
             stop "y and y_reconst do not match!"
         end if
+        call finalize_dmat(dm)
     end subroutine
 
 

--- a/test_sparse_ir.f90
+++ b/test_sparse_ir.f90
@@ -162,7 +162,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
 
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
 
@@ -242,7 +242,7 @@ program main
 
         deallocate(giv, gtau, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
     ! fermion
@@ -341,7 +341,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
     ! boson
@@ -440,7 +440,7 @@ program main
         deallocate(giv_smpl, gtau_smpl, gl_matsu, gl_tau, gtau_reconst, giv_reconst)
         deallocate(giv_ref, gtau_ref, g_spr, freq, tau)
         
-        !call finalize_ir(ir_obj)
+        call finalize_ir(ir_obj)
     end subroutine
 
 end program


### PR DESCRIPTION
1. `finalize_ir` was remade to deallocate all arrays of `IR`.
2. `set_beta` is changed so as not to call `decompose` when resetting `beta`; it multiplies the corresponding factors to dimensionless matrices and inverses of singular values.
3. test.yml was edited to test with intel compiler. 
